### PR TITLE
Raise error when lsb-release is not installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,9 @@ install:
 ifndef LATEXMK
 	@echo 'installing components...'
 ifeq ($(OS), Linux)
-ifeq ($(VERSION), 12.04)
+ifeq ($(VERSION), )
+	$(error lsb-release is not installed)
+else ifeq ($(VERSION), 12.04)
 	sudo apt-get install -y -qq texlive texlive-lang-cjk texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja dvipsk-ja gv latexmk
 else ifeq ($(VERSION), 14.04)
 	sudo apt install -y -qq texlive texlive-lang-cjk texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja dvipsk-ja gv latexmk


### PR DESCRIPTION
This PR enables you to make pdf on Ubuntu Precise without README instruction deleted at #6 
```bash
# On Ubuntu Precise docker
$ make
Makefile:40: *** lsb-release is not installed.  Stop.
$ sudo apt-get install lsb-release  # Just follow error message
...
$ make
installing components...
sudo apt-get install -y -qq texlive texlive-lang-cjk texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja dvipsk-ja gv latexmk
E: Unable to locate package texlive-lang-cjk
make: *** [install] Error 100
$ sudo apt-add-repository ppa:texlive-backports/ppa  # Google teaches us this is required for installing texlive-lang-cjk
sudo: apt-add-repository: command not found
$ sudo apt-get install python-software-properties  # Google teaches us this is required for using apt-add-repository
...
$ sudo apt-add-repository ppa:texlive-backports/ppa
...
$ sudo apt-get update  # Google teaches us this is required for installing texlive-lang-cjk
...
$ make
...
Accumulated processing time = 1.13
```